### PR TITLE
image crawler updates to handle MetaData and Pipeline grouping

### DIFF
--- a/image_crawler.py
+++ b/image_crawler.py
@@ -6,18 +6,36 @@ import json
 from utils.ConnectToDB import DBManager
 import cv2
 from datetime import datetime
+import json
 
 connector = None
 
 def scan_image_paths(locations):
     image_paths = []
-    for location in locations:
-        for root, dirs, files in os.walk(location):
+    
+    def recursive_scan(root_dir, current_metadata=None):
+        for root, dirs, files in os.walk(root_dir):
+            metadata_path = os.path.join(root, "metadata.json")
+            if os.path.isfile(metadata_path):
+                print(f'Found metadata file: {metadata_path}')
+                with open(metadata_path, 'r') as f:
+                    current_metadata = json.load(f)
+
+            # Process image files in the current directory
             for file in files:
-                if file.endswith(".png"):  # Configurable file type
+                if file.endswith(".png"):  # ignoring pdfs for now
                     full_path = os.path.join(root, file)
                     print(f'Found image: {full_path}')
-                    image_paths.append(full_path)
+                    
+                    image_paths.append({
+                        "path": full_path,
+                        "metadata": current_metadata
+                    })
+
+    # Start scanning from each specified location
+    for location in locations:
+        recursive_scan(location)
+    
     return image_paths
 
 def ensure_trailing_slash(path):
@@ -25,13 +43,89 @@ def ensure_trailing_slash(path):
         path += '/'
     return path
 
-def process_image(filepath):
+def get_super_plot_group_id():
+    query = 'SELECT ID FROM PlotGroups WHERE Name = "Pipeline"'
+    result = connector.FetchAll(query)
+    
+    if result:
+        super_plot_group_id = result[0]["ID"]
+        print(f'Using SuperPlotGroup_ID from PlotGroups where Name="Pipeline": {super_plot_group_id}')
+        return super_plot_group_id
+    else:
+        print("Error: 'Pipeline' entry not found in PlotGroups table.")
+        exit(1)
+
+def insert_into_supergroups(plot_group_id, super_plot_group_id):
+    supergroup_check_q = f'SELECT ID FROM SuperGroups WHERE PlotGroup_ID = {plot_group_id} AND SuperPlotGroup_ID = {super_plot_group_id}'
+    supergroup_check = connector.FetchAll(supergroup_check_q)
+    
+    if not supergroup_check:
+        #insert if it doesn't exist
+        supergroup_insert_q = f'''
+            INSERT INTO SuperGroups (PlotGroup_ID, SuperPlotGroup_ID)
+            VALUES ({plot_group_id},{super_plot_group_id})
+        ''' 
+        connector.Update(supergroup_insert_q)
+        print(f'Inserted PlotGroup_ID {plot_group_id} into SuperGroups with SuperPlotGroup_ID {super_plot_group_id}')
+    else:
+        print(f'SuperGroup entry already exists for PlotGroup_ID {plot_group_id} and SuperPlotGroup_ID {super_plot_group_id}')
+
+def process_image(filepath, metadata):
     try:
         plot = os.path.basename(filepath)
         locale, subloc = os.path.split(os.path.dirname(filepath))
+        print(f"scanning locale:  {locale}")
         print(f"Scanning sublocation: {subloc}")
+        
+        pipeline_id = None
+        plot_group_id = None
+        super_plot_group_id = None
+        
+        #if pipeline is in the path to the image, grab the pipeline number and add it into plot groups else continue
+        if 'pipeline' in locale:
+            super_plot_group_id = get_super_plot_group_id()
+            if super_plot_group_id is None:
+                print("Skipping SuperGroups insertion")
+                return
+            
+            locale_parts = locale.split(os.sep)
+            for part in locale_parts:
+                if part.startswith('pipeline-'):
+                    pipeline_id = part.split('pipeline-')[-1]
+                    break
+                
+            if pipeline_id:
+                print(f"found pipeline id: {pipeline_id}")
+                plot_group_q = f'SELECT ID FROM PlotGroups WHERE Name="{pipeline_id}"'
+                PlotGroup = connector.FetchAll(plot_group_q)
+                
+                if len(PlotGroup) == 0:
+                    insert_pg_q = f'INSERT INTO PlotGroups (Name) VALUES ("{pipeline_id}")'
+                    print(insert_pg_q)
+                    connector.Update(insert_pg_q)
+                    
+                    PlotGroup = connector.FetchAll(plot_group_q)
+                    if PlotGroup:
+                        plot_group_id = PlotGroup[0]["ID"]
+                        print(f'inserted new PlotGroup with ID: {plot_group_id}')
+                    else:
+                        print(f"Error: Could not retrieve PlotGroup ID for pipeline {pipeline_id}")
+                        return
+                        
+                else:
+                    plot_group_id = PlotGroup[0]['ID']
+                    print(f"PlotGroup already exists with ID: {plot_group_id}")
+            
+                if plot_group_id and super_plot_group_id:
+                    print(f'inserting into supergroups {plot_group_id} and {super_plot_group_id}')
+                    insert_into_supergroups(plot_group_id, super_plot_group_id)
+            else:
+                print(f"coud not find pipeline id in locale: {locale}")
+        else:
+            print('no pipeline in locale')
+    
 
-        RunNumber = 0  # Always zero
+        RunNumber = 0
         RunPeriod = ensure_trailing_slash(f"{locale}/{subloc}")
         Name = plot.rsplit(".", 1)[0]
 
@@ -47,7 +141,7 @@ def process_image(filepath):
             PT_ID = Plot_Type_ID[0]["ID"]
             print(f'Plot type ID: {PT_ID}')
 
-        unique_plot_q = f'SELECT ID, ForcedTraining FROM Plots WHERE Plot_Types_ID={PT_ID} AND RunNumber={RunNumber} AND RunPeriod="{RunPeriod}"'
+        unique_plot_q = f'SELECT ID FROM Plots WHERE Plot_Types_ID={PT_ID} AND RunNumber={RunNumber} AND RunPeriod="{RunPeriod}"'
         Plot = connector.FetchAll(unique_plot_q)
 
         if len(Plot) == 0:
@@ -55,7 +149,12 @@ def process_image(filepath):
             if read_img is None or read_img.size == 0:
                 return
             print("Inserting plot")
-            insert_q = f'INSERT INTO Plots (Plot_Types_ID, RunPeriod, RunNumber, DateTime) VALUES ({PT_ID}, "{RunPeriod}", {RunNumber}, NOW())'
+            # Insert into Plots with MetaData as NULL if metadata is None
+            metadata_value = "NULL" if metadata is None else f"'{json.dumps(metadata)}'"
+            insert_q = f'''
+                INSERT INTO Plots (Plot_Types_ID, RunPeriod, RunNumber, InsertDateTime, MetaData)
+                VALUES ({PT_ID}, "{RunPeriod}", {RunNumber}, NOW(), {metadata_value})
+            '''
             connector.Update(insert_q)
         else:
             print("Plot already inserted")
@@ -79,7 +178,7 @@ def main(argv):
         exit(1)
 
     connector = DBManager(configPath=configPath)
-
+    
     crawler_pidFile = f"/tmp/{str(locations_to_scan[0]).replace('/', '_')}_img_crawler_pid"
     if os.path.exists(crawler_pidFile):
         try:
@@ -98,8 +197,8 @@ def main(argv):
     print(f"Scanning: {locations_to_scan}")
     image_paths = scan_image_paths(locations_to_scan)
 
-    for image_path in image_paths:
-        process_image(image_path)
+    for image in image_paths:
+        process_image(image["path"], image["metadata"])
 
 if __name__ == "__main__":
     main(sys.argv[1:])


### PR DESCRIPTION
script was modified to:

include MetaData (from metadata.json) for each image in the same directory and sublevel directories. MetaData is inserted into Plots and will be visible on UI 

insert the pipeline id from gitlab into the PlotGroups table
insert the corresponding ID in the database from above and the ID corresponding to Pipeline in the SuperGroups table. 

This basically says an individual pipeline is a group of images, and those pipelines belong to the Pipeline SuperGroup. The SuperGroups table helps auto-populate the sidebar that appears on the UI.
